### PR TITLE
Add basic minutas creation and entry modals

### DIFF
--- a/src/components/AddEntryModal.tsx
+++ b/src/components/AddEntryModal.tsx
@@ -1,0 +1,48 @@
+'use client';
+import { useState } from 'react';
+import UserSearch, { Responsable } from './UserSearch';
+
+interface Props {
+  onAdd(entry: {
+    title: string;
+    responsables: Responsable[];
+  }): void;
+  onClose(): void;
+}
+
+export default function AddEntryModal({ onAdd, onClose }: Props) {
+  const [title, setTitle] = useState('');
+  const [responsables, setResponsables] = useState<Responsable[]>([]);
+
+  const submit = () => {
+    if (!title.trim()) return;
+    onAdd({ title: title.trim(), responsables });
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
+      <div className="bg-white p-4 rounded w-full max-w-lg space-y-3">
+        <h2 className="text-lg font-semibold">Nuevo Acuerdo</h2>
+        <textarea
+          className="border p-1 w-full h-24"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+        />
+        <UserSearch value={responsables} onChange={setResponsables} />
+        <div className="flex justify-end gap-2 pt-2">
+          <button type="button" onClick={onClose} className="border px-3 py-1 rounded">
+            Cancelar
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            className="bg-blue-600 text-white px-3 py-1 rounded"
+          >
+            Agregar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CreateGroupModal.tsx
+++ b/src/components/CreateGroupModal.tsx
@@ -1,0 +1,44 @@
+'use client';
+import { useState } from 'react';
+
+interface Props {
+  onCreate(title: string): void;
+  onClose(): void;
+}
+
+export default function CreateGroupModal({ onCreate, onClose }: Props) {
+  const [title, setTitle] = useState('');
+
+  const submit = () => {
+    if (!title.trim()) return;
+    onCreate(title.trim());
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
+      <div className="bg-white p-4 rounded w-full max-w-sm space-y-3">
+        <h2 className="text-lg font-semibold">Nueva Minuta</h2>
+        <input
+          type="text"
+          className="border p-1 w-full"
+          placeholder="Título de la minuta"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+        />
+        <div className="flex justify-end gap-2 pt-2">
+          <button type="button" onClick={onClose} className="border px-3 py-1 rounded">
+            Cancelar
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            className="bg-blue-600 text-white px-3 py-1 rounded"
+          >
+            Crear
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `CreateGroupModal` to create new minutas
- add `AddEntryModal` to add new agreements to groups
- allow creating and deleting minutas and adding entries on the agreements page

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683fa52a875c8320862d40d25be39578